### PR TITLE
Expose InnerResponse, Http properties

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -1089,6 +1089,11 @@ module private HttpHelpers =
 
         let responseStream = res.GetResponseStream() |> copyToMemoryStream
 
+        let httpProperty f = 
+            match res with
+              | :? HttpWebResponse as httpRes -> Some (f httpRes)
+              | _ -> None
+
         override x.Headers = res.Headers
         override x.ResponseUri = res.ResponseUri
         override x.ContentType = res.ContentType
@@ -1100,6 +1105,18 @@ module private HttpHelpers =
         override x.GetResponseStream () = responseStream :> Stream
         member x.ResetResponseStream () = responseStream.Position <- 0L
 
+        member x.CharacterSet = httpProperty (fun r -> r.CharacterSet)
+        member x.ContentEncoding = httpProperty (fun r -> r.ContentEncoding)
+        member x.Cookies = httpProperty (fun r -> r.Cookies)
+        member x.LastModified = httpProperty (fun r -> r.LastModified)
+        member x.Method = httpProperty (fun r -> r.Method)
+        member x.ProtocolVersion = httpProperty (fun r -> r.ProtocolVersion)
+        member x.Server = httpProperty (fun r -> r.Server)
+        member x.StatusCode = httpProperty (fun r -> r.StatusCode)        
+        member x.StatusDescription = httpProperty (fun r -> r.StatusDescription)
+
+        member x.InnerResponse = res
+        
         interface IDisposable with
             member x.Dispose () =
                 match res :> obj with


### PR DESCRIPTION
The current `FSharp.Data.WebResponse` wrapper does not allow the user to access the original response.

In particular, the `WebResponse` will normally (always?) be a `HttpWebResponse`, which exposes critical properties like `StatusCode`, which are currently inaccessible save through parsing the added line in `Message`.

This PR adds:

 - a set of properties that wrap those in [HttpWebResponse](https://docs.microsoft.com/it-it/dotnet/api/system.net.httpwebresponse?view=netframework-4.8), returning `None` if the wrapped response isn't a `HttpWebResponse` 

 - an `InnerResponse` property that exposes the original `WebResponse`, for anything a user might need.